### PR TITLE
Chore: Update Vite configuration to include build settings

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,7 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    outDir: "build",
+  },
 });


### PR DESCRIPTION
This pull request makes a small configuration change to the Vite setup. The build output directory is now explicitly set to `"build"`.